### PR TITLE
Fixes #13 - Error on single day compliance frequency

### DIFF
--- a/aws-control-tower-securityhub-enabler.template
+++ b/aws-control-tower-securityhub-enabler.template
@@ -72,7 +72,10 @@ Parameters:
     AllowedValues:
       - "Yes"
       - "No"
-
+Conditions:
+  ComplianceFrequencySingleDay: !Equals
+    - !Ref 'ComplianceFrequency'
+    - 1
 
 Resources:
   SecurityHubEnablerRole: 
@@ -212,7 +215,10 @@ Resources:
     Type: AWS::Events::Rule
     Properties: 
       Description: "SecurityHubScheduledComplianceTrigger"
-      ScheduleExpression: !Sub "rate(${ComplianceFrequency} days)"
+      ScheduleExpression: !If
+        - ComplianceFrequencySingleDay
+        - !Sub "rate(${ComplianceFrequency} day)"
+        - !Sub "rate(${ComplianceFrequency} days)"
       State: "ENABLED"
       Targets: 
         - 


### PR DESCRIPTION
Fixes issue https://github.com/aws-samples/aws-control-tower-securityhub-enabler/issues/13

Add an condition to output "day" or "days" depending on whether or not a
single day is specified for the ComplianceFrequency parameter.

![image](https://user-images.githubusercontent.com/1034154/86080317-c1822e00-bae6-11ea-90cd-1e7c675f3ed8.png)
![image](https://user-images.githubusercontent.com/1034154/86080336-cf37b380-bae6-11ea-99f1-f5860f918e16.png)
![image](https://user-images.githubusercontent.com/1034154/86080595-60a72580-bae7-11ea-8899-85c9b670d5cd.png)
![image](https://user-images.githubusercontent.com/1034154/86080570-5553fa00-bae7-11ea-9ea5-50ba244812af.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
